### PR TITLE
Fixed pattern missing relationship

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # OWL Ontology Verbalizer
 
+![PyPI - Version](https://img.shields.io/pypi/v/ontology-verbalizer)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/ontology-verbalizer)
+![](https://github.com/Minitour/ontology-verbalizer/actions/workflows/release.yml/badge.svg)
+
+
 ## Installation
 
 ```shell

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ontology-verbalizer"
-version = "1.1.1"
+version = "1.1.2"
 description = "A Python package for ontology verbalization"
 authors = ["Antonio Zaitoun <tony.z.1711@gmail.com>"]
 license = "MIT"

--- a/tests/test_verbalization.py
+++ b/tests/test_verbalization.py
@@ -5,8 +5,10 @@ from rdflib import Graph
 
 from verbalizer.process import Processor
 from verbalizer.sampler import Sampler
+from verbalizer.verbalizer import VerbalizationError, VerbalizationInitError
 from verbalizer.vocabulary import Vocabulary
 from verbalizer import Verbalizer
+from verbalizer.patterns import owl_disjoint, owl_restriction, owl_first_rest
 
 rename_iri = {
     'http://www.w3.org/2002/07/owl#equivalentClass': 'is same as',
@@ -78,3 +80,14 @@ class TestVerbalization(unittest.TestCase):
         results = Processor.verbalize_with(verbalizer, namespace='foaf', as_generator=True)
         self.assertTrue(isinstance(results, types.GeneratorType))
         self.assertEqual(12, len(list(results)))
+
+    def test_with_error_with_pattern(self):
+        ignore = {
+            "http://www.w3.org/2002/07/owl#disjointWith"
+        }
+        patterns = [owl_disjoint.OwlDisjointWith, owl_restriction.OwlRestrictionPattern,
+                    owl_first_rest.OwlFirstRestPattern]
+        ontology = Processor.from_file('./data/foaf.owl')
+        vocabulary = Vocabulary(ontology, ignore=ignore, rephrased=rename_iri)
+        with self.assertRaises(VerbalizationInitError):
+            verbalizer = Verbalizer(vocabulary, patterns=patterns)

--- a/verbalizer/patterns/__init__.py
+++ b/verbalizer/patterns/__init__.py
@@ -35,3 +35,7 @@ class Pattern(ABC):
         regardless of whether they were used or not in the construction of the nodes and edges.
         """
         return []
+
+    @classmethod
+    def guarded_iris(cls) -> set[str]:
+        return set()

--- a/verbalizer/patterns/owl_disjoint.py
+++ b/verbalizer/patterns/owl_disjoint.py
@@ -1,7 +1,7 @@
 from rdflib import URIRef
 
 from verbalizer.patterns import Pattern
-from verbalizer.verbalizer import VerbalizationNode, VerbalizationEdge, default_patterns
+from verbalizer.verbalizer import VerbalizationNode, VerbalizationEdge
 from verbalizer.vocabulary import Vocabulary
 
 
@@ -58,4 +58,6 @@ class OwlDisjointWith(Pattern):
 
         return [(reference.relationship, reference.node.concept) for reference in node.references]
 
-default_patterns.append(OwlDisjointWith)
+    @classmethod
+    def guarded_iris(cls) -> set[str]:
+        return {cls.disjoint_relation}

--- a/verbalizer/patterns/owl_first_rest.py
+++ b/verbalizer/patterns/owl_first_rest.py
@@ -1,7 +1,7 @@
 from verbalizer.patterns import Pattern
 from rdflib import URIRef
 
-from verbalizer.verbalizer import VerbalizationNode, VerbalizationEdge, default_patterns
+from verbalizer.verbalizer import VerbalizationNode, VerbalizationEdge
 
 
 class OwlFirstRestPattern(Pattern):
@@ -38,4 +38,6 @@ class OwlFirstRestPattern(Pattern):
 
         return [(reference.relationship, reference.node.concept) for reference in node.references]
 
-default_patterns.append(OwlFirstRestPattern)
+    @classmethod
+    def guarded_iris(cls) -> set[str]:
+        return set()

--- a/verbalizer/patterns/owl_restriction.py
+++ b/verbalizer/patterns/owl_restriction.py
@@ -1,7 +1,7 @@
 from rdflib import URIRef
 
 from verbalizer.patterns import Pattern
-from verbalizer.verbalizer import VerbalizationNode, VerbalizationEdge, default_patterns
+from verbalizer.verbalizer import VerbalizationNode, VerbalizationEdge
 
 
 class OwlRestrictionPattern(Pattern):
@@ -63,7 +63,7 @@ class OwlRestrictionPattern(Pattern):
                 quantifier_relation = relation
                 literal_value = obj
 
-                # initialize next_node only if it hasn't be initialized yet.
+                # initialize next_node only if it hasn't been initialized yet.
                 if next_node is None:
                     next_node = VerbalizationNode(
                         concept='',
@@ -128,4 +128,17 @@ class OwlRestrictionPattern(Pattern):
         elif quantifier_relation.endswith('maxCardinality') or quantifier_relation.endswith('maxQualifiedCardinality'):
             return f'has at most {literal_value}{on_class_label}{property_relation_label}{relation_plural_s}'
 
-default_patterns.append(OwlRestrictionPattern)
+    @classmethod
+    def guarded_iris(cls) -> set[str]:
+        return {
+            'http://www.w3.org/2002/07/owl#someValuesFrom',
+            'http://www.w3.org/2002/07/owl#allValuesFrom',
+            'http://www.w3.org/2002/07/owl#hasValue',
+            'http://www.w3.org/2002/07/owl#cardinality',
+            'http://www.w3.org/2002/07/owl#minCardinality',
+            'http://www.w3.org/2002/07/owl#maxCardinality',
+            'http://www.w3.org/2002/07/owl#qualifiedCardinality',
+            'http://www.w3.org/2002/07/owl#minQualifiedCardinality',
+            'http://www.w3.org/2002/07/owl#maxQualifiedCardinality',
+            'http://www.w3.org/2002/07/owl#onClass'
+        }


### PR DESCRIPTION
Fixed bug where a pattern can use a relationship that is ignored by the vocabulary, resulting in incorrect verbalizations and exceptions.

Now an exception is raised during init of the verbalizer if there is a conflict .